### PR TITLE
Replace ENCHANT_NAME to valid name

### DIFF
--- a/src/main/java/fr/zcraft/zlib/tools/items/GlowEffect.java
+++ b/src/main/java/fr/zcraft/zlib/tools/items/GlowEffect.java
@@ -29,14 +29,15 @@
  */
 package fr.zcraft.zlib.tools.items;
 
-import fr.zcraft.zlib.tools.PluginLogger;
+import java.lang.reflect.Field;
+
 import org.bukkit.NamespacedKey;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.enchantments.EnchantmentTarget;
 import org.bukkit.enchantments.EnchantmentWrapper;
 import org.bukkit.inventory.ItemStack;
 
-import java.lang.reflect.Field;
+import fr.zcraft.zlib.tools.PluginLogger;
 
 /**
  * A fake enchantment to add a glowing effect on any item.
@@ -45,8 +46,7 @@ import java.lang.reflect.Field;
  */
 public class GlowEffect extends EnchantmentWrapper
 {
-    private final static int ENCHANTMENT_ID = 254;
-    private final static String ENCHANTMENT_NAME = "GlowEffect";
+    private final static String ENCHANTMENT_NAME = "durability";
     private static Enchantment glow;
 
     protected GlowEffect(String name)


### PR DESCRIPTION
IllegalArgumentException occurs when using GlowEffect because the effect name ”GlowEffect” is invalid.
```
[23:14:22 WARN]: [SpectatorPlus] Task #2517 for SpectatorPlus v3.1 generated an exception
java.lang.IllegalArgumentException: Invalid key. Must be [a-z0-9/._-]: GlowEffect
	at com.google.common.base.Preconditions.checkArgument(Preconditions.java:191) ~[patched_1.13.2.jar:git-Paper-651]
	at org.bukkit.NamespacedKey.<init>(NamespacedKey.java:49) ~[patched_1.13.2.jar:git-Paper-651]
	at org.bukkit.NamespacedKey.minecraft(NamespacedKey.java:142) ~[patched_1.13.2.jar:git-Paper-651]
	at com.pgcraft.spectatorplus.zlib.tools.items.GlowEffect.getGlow(GlowEffect.java:90) ~[?:?]
	at com.pgcraft.spectatorplus.zlib.tools.items.GlowEffect.addGlow(GlowEffect.java:108) ~[?:?]
	at com.pgcraft.spectatorplus.guis.SpectatorsToolsGUI.onUpdate(SpectatorsToolsGUI.java:108) ~[?:?]
	at com.pgcraft.spectatorplus.zlib.components.gui.GuiBase.update(GuiBase.java:80) ~[?:?]
	at com.pgcraft.spectatorplus.zlib.components.gui.InventoryGui.update(InventoryGui.java:81) ~[?:?]
	at com.pgcraft.spectatorplus.zlib.components.gui.ActionGui.update(ActionGui.java:299) ~[?:?]
	at com.pgcraft.spectatorplus.zlib.components.gui.GuiBase.open(GuiBase.java:140) ~[?:?]
	at com.pgcraft.spectatorplus.zlib.components.gui.InventoryGui.open(InventoryGui.java:117) ~[?:?]
	at com.pgcraft.spectatorplus.zlib.components.gui.Gui$1.run(Gui.java:112) ~[?:?]
	at org.bukkit.craftbukkit.v1_13_R2.scheduler.CraftTask.run(CraftTask.java:84) ~[patched_1.13.2.jar:git-Paper-651]
	at org.bukkit.craftbukkit.v1_13_R2.scheduler.CraftScheduler.mainThreadHeartbeat(CraftScheduler.java:449) ~[patched_1.13.2.jar:git-Paper-651]
	at net.minecraft.server.v1_13_R2.MinecraftServer.b(MinecraftServer.java:1010) ~[patched_1.13.2.jar:git-Paper-651]
	at net.minecraft.server.v1_13_R2.DedicatedServer.b(DedicatedServer.java:439) ~[patched_1.13.2.jar:git-Paper-651]
	at net.minecraft.server.v1_13_R2.MinecraftServer.a(MinecraftServer.java:940) ~[patched_1.13.2.jar:git-Paper-651]
	at net.minecraft.server.v1_13_R2.MinecraftServer.run(MinecraftServer.java:837) ~[patched_1.13.2.jar:git-Paper-651]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_212]
```
This pull request replaces a valid enchantment name and it works correctly with SpectatorPlus-1.13.2.
https://github.com/fubira/SpectatorPlus

